### PR TITLE
PILOT-1107: Replace project_id with project_code

### DIFF
--- a/api/api_files/__init__.py
+++ b/api/api_files/__init__.py
@@ -1,6 +1,6 @@
 # from ..upload_ops import CheckUploadStateRestful
 from .vfolder_ops import VirtualFolderFiles, VirtualFolder, VirtualFolderInfo
-from .file_ops import FileActions, FileActionTasks, FileValidation, FileRepeatedCheck
+from .file_ops import FileActions, FileActionTasks
 from .file_search import FileSearch
 from .meta import FileMeta, FileDetailBulk
 from .file_stats import FileStatistics
@@ -14,8 +14,6 @@ nfs_entity_ns.add_resource(FileActionTasks, '/actions/tasks')
 nfs_entity_ns.add_resource(FileMeta, '/meta')
 nfs_entity_ns.add_resource(FileDetailBulk, '/bulk/detail')
 nfs_entity_ns.add_resource(FileStatistics, '/project/<project_geid>/files/statistics')
-nfs_entity_ns.add_resource(FileValidation, '/validation')
-nfs_entity_ns.add_resource(FileRepeatedCheck, '/repeatcheck')
 
 
 nfs_upload_ns = Namespace('Data Upload', description='Upload data', path='/v1/upload')

--- a/api/api_files/file_ops.py
+++ b/api/api_files/file_ops.py
@@ -45,7 +45,7 @@ class FileActionTasks(Resource):
 class FileActions(Resource):
     @jwt_required()
     def post(self):
-        data_actions_utility_url = 'http://127.0.0.1:5063/v1/' + "files/actions/"
+        data_actions_utility_url = ConfigClass.DATA_UTILITY_SERVICE + "files/actions/"
         headers = request.headers
         request_body = request.get_json()
         validate_request_params(request_body)


### PR DESCRIPTION
## Summary

- Replace project_id in payload with project_code. Front-end and queue service will be making necessary changes as well.
- Removed deprecated dataops endpoints (`files/actions/validate/repeat-check` and `files/actions/validate`).


## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1107

## Type of Change

Please delete options that are not relevant.

- [X] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)

