### PR TITLE
PILOT-1113: Fix error for non-admin manifest attribute attach

### DIFF
--- a/api/api_data_manifest/data_manifest.py
+++ b/api/api_data_manifest/data_manifest.py
@@ -39,8 +39,6 @@ class APIDataManifest(metaclass=MetaAPI):
         api_ns_data_manifest.add_resource(
             self.ImportManifest, '/import/manifest')
         api_ns_data_manifest.add_resource(
-            self.ExportManifest, '/export/manifest')
-        api_ns_data_manifest.add_resource(
             self.FileManifestQuery, '/file/manifest/query')
         api_ns_data_manifest.add_resource(
             self.AttachAttributes, '/file/attributes/attach')
@@ -89,7 +87,7 @@ class APIDataManifest(metaclass=MetaAPI):
                 response = requests.get(
                     ConfigClass.METADATA_SERVICE + f'template/{manifest_id}/')
                 res = response.json()
-                if not res:
+                if not res['result']:
                     my_res.set_code(EAPIResponseCode.not_found)
                     my_res.set_error_msg('Attribute template not found')
                     return my_res.to_dict, my_res.code
@@ -278,42 +276,6 @@ class APIDataManifest(metaclass=MetaAPI):
                 res = response.json()
                 res['result'] = 'Success'
                 return res, response.status_code
-            except Exception as e:
-                _logger.error(
-                    f'Error when calling metadata service: {str(e)}')
-                error_msg = {
-                    'result': str(e)
-                }
-                return error_msg, 500
-
-    class ExportManifest(Resource):
-        """Export attribute template from portal as JSON."""
-
-        @jwt_required()
-        def get(self):
-            api_response = APIResponse()
-            template_id = request.args.get('manifest_id')
-            if not template_id:
-                api_response.set_code(EAPIResponseCode.bad_request)
-                api_response.set_result('Missing required field template_id')
-                return api_response.to_dict, api_response.code
-
-            try:
-                response = requests.get(
-                    ConfigClass.METADATA_SERVICE + f'template/{template_id}/')
-                if not response:
-                    api_response.set_code(EAPIResponseCode.not_found)
-                    api_response.set_error_msg('Attribute template not found')
-                    return api_response.to_dict, api_response.code
-
-                template = response.json()['result']
-                if not has_permission(template['project_code'], 'file_attribute_template', '*', 'export'):
-                    api_response.set_code(EAPIResponseCode.forbidden)
-                    api_response.set_result('Permission Denied')
-                    return api_response.to_dict, api_response.code
-
-                attributes = {'attributes': response.json()['result']['attributes']}
-                return attributes, response.status_code
             except Exception as e:
                 _logger.error(
                     f'Error when calling metadata service: {str(e)}')

--- a/api/api_data_manifest/data_manifest.py
+++ b/api/api_data_manifest/data_manifest.py
@@ -1,21 +1,25 @@
 import requests
-
-from flask import request
-from flask_jwt import current_identity, jwt_required
-from flask_restx import Resource
 from common import LoggerFactory
+from flask import request
+from flask_jwt import current_identity
+from flask_jwt import jwt_required
+from flask_restx import Resource
 
 from api import module_api
 from config import ConfigClass
 from models.api_meta_class import MetaAPI
-from models.api_response import APIResponse, EAPIResponseCode
+from models.api_response import APIResponse
+from models.api_response import EAPIResponseCode
 from resources.error_handler import APIException
-from resources.swagger_modules import data_manifests, data_manifests_return
+from resources.swagger_modules import data_manifests
+from resources.swagger_modules import data_manifests_return
 from services.meta import get_entity_by_id
 from services.permissions_service.decorators import permissions_check
-from services.permissions_service.utils import get_project_role, has_permission
+from services.permissions_service.utils import get_project_role
+from services.permissions_service.utils import has_permission
 
-from .utils import has_permissions, is_greenroom
+from .utils import has_permissions
+from .utils import is_greenroom
 
 api_ns_data_manifests = module_api.namespace(
     'Attribute Templates Restful', description='For data attribute templates feature', path='/v1')
@@ -47,9 +51,7 @@ class APIDataManifest(metaclass=MetaAPI):
         @jwt_required()
         @permissions_check('file_attribute_template', '*', 'view')
         def get(self):
-            '''
-            List attribute templates by project_code
-            '''
+            """List attribute templates by project_code."""
             try:
                 response = requests.get(
                     ConfigClass.METADATA_SERVICE + 'template/', params=request.args)
@@ -65,9 +67,7 @@ class APIDataManifest(metaclass=MetaAPI):
         @jwt_required()
         @permissions_check('file_attribute_template', '*', 'create')
         def post(self):
-            '''
-            Create a new attribute template
-            '''
+            """Create a new attribute template."""
             try:
                 response = requests.post(
                     ConfigClass.METADATA_SERVICE + 'template/', json=request.get_json())
@@ -83,9 +83,7 @@ class APIDataManifest(metaclass=MetaAPI):
     class RestfulManifest(Resource):
         @jwt_required()
         def get(self, manifest_id):
-            '''
-            Get an attribute template by id
-            '''
+            """Get an attribute template by id."""
             my_res = APIResponse()
             try:
                 response = requests.get(
@@ -109,9 +107,7 @@ class APIDataManifest(metaclass=MetaAPI):
 
         @jwt_required()
         def put(self, manifest_id):
-            '''
-            Update attributes or name of template by id
-            '''
+            """Update attributes or name of template by id."""
             my_res = APIResponse()
             data = request.get_json()
             project_code = data.get('project_code')
@@ -134,7 +130,7 @@ class APIDataManifest(metaclass=MetaAPI):
                     result = {'id': template['id'], 'name': template['name'], 'project_code': template['project_code']}
                     data['attributes'] = template['attributes']
                 else:
-                    result = ""
+                    result = ''
                     existing_attr = template['attributes']
                     data['attributes'] = data['attributes'] + existing_attr
 
@@ -154,9 +150,7 @@ class APIDataManifest(metaclass=MetaAPI):
 
         @jwt_required()
         def delete(self, manifest_id):
-            '''
-            Delete an attribute template
-            '''
+            """Delete an attribute template."""
             my_res = APIResponse()
             data = request.get_json()
             project_code = data.get('project_code')
@@ -205,9 +199,7 @@ class APIDataManifest(metaclass=MetaAPI):
                 return error_msg, 500
 
     class FileAttributes(Resource):
-        '''
-        Update attributes of template attached to a file
-        '''
+        """Update attributes of template attached to a file."""
 
         @jwt_required()
         def put(self, file_geid):
@@ -268,9 +260,7 @@ class APIDataManifest(metaclass=MetaAPI):
                 return error_msg, 500
 
     class ImportManifest(Resource):
-        '''
-        Import attribute template from portal as JSON
-        '''
+        """Import attribute template from portal as JSON."""
 
         @jwt_required()
         @permissions_check('file_attribute_template', '*', 'import')
@@ -297,9 +287,7 @@ class APIDataManifest(metaclass=MetaAPI):
                 return error_msg, 500
 
     class ExportManifest(Resource):
-        '''
-        Export attribute template from portal as JSON
-        '''
+        """Export attribute template from portal as JSON."""
 
         @jwt_required()
         def get(self):
@@ -307,7 +295,7 @@ class APIDataManifest(metaclass=MetaAPI):
             template_id = request.args.get('manifest_id')
             if not template_id:
                 api_response.set_code(EAPIResponseCode.bad_request)
-                api_response.set_result(f'Missing required field template_id')
+                api_response.set_result('Missing required field template_id')
                 return api_response.to_dict, api_response.code
 
             try:
@@ -335,9 +323,7 @@ class APIDataManifest(metaclass=MetaAPI):
                 return error_msg, 500
 
     class FileManifestQuery(Resource):
-        '''
-        List template attributes for files
-        '''
+        """List template attributes for files."""
 
         @jwt_required()
         def post(self):
@@ -345,7 +331,7 @@ class APIDataManifest(metaclass=MetaAPI):
             data = request.get_json()
             if 'geid_list' not in data:
                 api_response.set_code(EAPIResponseCode.bad_request)
-                api_response.set_result(f'Missing required field: geid_list')
+                api_response.set_result('Missing required field: geid_list')
                 return api_response.to_dict, api_response.code
 
             geid_list = data.get('geid_list')
@@ -359,7 +345,7 @@ class APIDataManifest(metaclass=MetaAPI):
                         template_id = list(entity['extended']['extra']['attributes'].keys())[0]
                         if not has_permissions(template_id, entity) and not lineage_view:
                             api_response.set_code(EAPIResponseCode.forbidden)
-                            api_response.set_result(f'Permission denied')
+                            api_response.set_result('Permission denied')
                             return api_response.to_dict, api_response.code
                         if is_greenroom(entity):
                             zone = 'greenroom'
@@ -380,7 +366,7 @@ class APIDataManifest(metaclass=MetaAPI):
                             template_info = response.json()['result']
                             template_name = template_info['name']
                             for attr, value in entity_attributes[template_id].items():
-                                attr_info = next(item for item in template_info['attributes'] if item["name"] == attr)
+                                attr_info = next(item for item in template_info['attributes'] if item['name'] == attr)
                                 attribute = {
                                     'id': extended_id,
                                     'name': attr,
@@ -404,9 +390,7 @@ class APIDataManifest(metaclass=MetaAPI):
                 return error_msg, 500
 
     class AttachAttributes(Resource):
-        """
-        Attach attributes to files or folders (bequeath)
-        """
+        """Attach attributes to files or folders (bequeath)"""
 
         @jwt_required()
         def post(self):
@@ -414,7 +398,7 @@ class APIDataManifest(metaclass=MetaAPI):
             required_fields = ['manifest_id', 'item_ids', 'attributes', 'project_code']
             data = request.get_json()
             payload = {'items': []}
-            responses = {"result": []}
+            responses = {'result': []}
             # Check required fields
             for field in required_fields:
                 if field not in data:
@@ -430,7 +414,7 @@ class APIDataManifest(metaclass=MetaAPI):
                     project_role = get_project_role(project_code)
                     if not project_role:
                         api_response.set_code(EAPIResponseCode.forbidden)
-                        api_response.set_result(f'User does not have access to this project')
+                        api_response.set_result('User does not have access to this project')
                         return api_response.to_dict, api_response.code
 
                     for item in item_ids:
@@ -440,12 +424,12 @@ class APIDataManifest(metaclass=MetaAPI):
                         if project_role == 'collaborator':
                             if zone == 'greenroom' and root_folder != current_identity['username']:
                                 api_response.set_code(EAPIResponseCode.forbidden)
-                                api_response.set_result(f'Permission denied')
+                                api_response.set_result('Permission denied')
                                 return api_response.to_dict, api_response.code
                         elif project_role == 'contributor':
                             if root_folder != current_identity['username']:
                                 api_response.set_code(EAPIResponseCode.forbidden)
-                                api_response.set_result(f'Permission denied')
+                                api_response.set_result('Permission denied')
                                 return api_response.to_dict, api_response.code
                         items.append(entity)
                 else:
@@ -501,8 +485,8 @@ class APIDataManifest(metaclass=MetaAPI):
                         api_response.set_result(response.text)
                         return api_response.to_dict, api_response.code
                     for item in response.json()['result']:
-                        responses['result'].append({'name': item['name'], "geid": item['id'],
-                                                    "operation_status": "SUCCEED"})
+                        responses['result'].append({'name': item['name'], 'geid': item['id'],
+                                                    'operation_status': 'SUCCEED'})
 
                 responses['total'] = len(responses['result'])
                 api_response.set_result(responses)

--- a/tests/api/api_template/test_template.py
+++ b/tests/api/api_template/test_template.py
@@ -1,4 +1,3 @@
-import pytest
 from uuid import uuid4
 from config import ConfigClass
 
@@ -17,7 +16,7 @@ MOCK_FILE_DATA = {
     },
     'id': str(uuid4()),
     'last_updated_time': '2021-05-10 19:43:55.383021',
-    'name': 'jiang_folder_2',
+    'name': 'folder2',
     'owner': 'admin',
     'parent': str(uuid4()),
     'parent_path': 'test',
@@ -77,7 +76,8 @@ MOCK_TEMPLATE_DATA = {
                 'A',
                 'B',
                 'C'
-            ]
+            ],
+            'manifest_id': template_id
         }
     ]
 }
@@ -121,9 +121,9 @@ def test_get_template_by_id_admin_200(test_client, requests_mocker, jwt_token_ad
     requests_mocker.get(ConfigClass.AUTH_SERVICE + 'authorize', json=mock_data)
 
     mock_data = {
-        'result': [
+        'result':
             MOCK_TEMPLATE_DATA
-        ]
+
     }
     requests_mocker.get(ConfigClass.METADATA_SERVICE + f'template/{template_id}/', json=mock_data)
 
@@ -138,8 +138,7 @@ def test_get_template_by_invalid_id_admin_404(test_client, requests_mocker, jwt_
     requests_mocker.get(ConfigClass.AUTH_SERVICE + 'authorize', json=mock_data)
 
     mock_data = {
-        'result': [
-        ]
+        'result': {}
     }
     requests_mocker.get(ConfigClass.METADATA_SERVICE + f'template/{invalid_id}/', json=mock_data)
 
@@ -152,12 +151,19 @@ def test_update_template_attributes_admin_200(test_client, requests_mocker, jwt_
                                               has_permission_true):
     MOCK_TEMPLATE_UPDATE = MOCK_TEMPLATE_DATA.copy()
     MOCK_TEMPLATE_UPDATE['attributes'][0]['name'] = 'attr2'
-    mock_data = {
+
+    mock_data_1 = {
+        'result': MOCK_TEMPLATE_DATA
+    }
+
+    mock_data_2 = {
         'result': [
             MOCK_TEMPLATE_UPDATE
         ]
     }
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'template/', json=mock_data)
+
+    requests_mocker.get(ConfigClass.METADATA_SERVICE + f'template/{template_id}/', json=mock_data_1)
+    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'template/', json=mock_data_2)
 
     headers = {'Authorization': jwt_token_admin}
     response = test_client.put(f'v1/data/manifest/{template_id}', json=MOCK_TEMPLATE_UPDATE, headers=headers)
@@ -185,6 +191,8 @@ def test_delete_template_by_id_admin_200(test_client, requests_mocker, jwt_token
         'result': [
         ]
     }
+
+    requests_mocker.get(ConfigClass.METADATA_SERVICE + 'items/search/', json=mock_data)
     requests_mocker.delete(ConfigClass.METADATA_SERVICE + f'template/?id={template_id}', json=mock_data)
 
     payload = {'project_code': 'test_project'}
@@ -213,9 +221,7 @@ def test_update_template_attributes_of_file_admin_200(test_client, requests_mock
     # mock update item attributes by id
     MOCK_FILE_DATA_ATTR['extended']['extra']['attributes'] = {template_id: {'attr1': 'B'}}
     mock_data = {
-        'result': [
-            MOCK_FILE_DATA_ATTR
-        ]
+        'result': MOCK_FILE_DATA_ATTR
     }
     requests_mocker.put(ConfigClass.METADATA_SERVICE + f'item/?id={file_id}', json=mock_data)
 
@@ -269,21 +275,6 @@ def test_import_template_admin_200(test_client, requests_mocker, jwt_token_admin
 
     headers = {'Authorization': jwt_token_admin}
     response = test_client.post('v1/import/manifest', json=MOCK_TEMPLATE_DATA, headers=headers)
-    assert response.status_code == 200
-
-
-def test_export_template_admin_200(test_client, requests_mocker, jwt_token_admin):
-    mock_data = {'result': {'has_permission': 'True'}}
-    requests_mocker.get(ConfigClass.AUTH_SERVICE + 'authorize', json=mock_data)
-
-    mock_data = {
-        'result': MOCK_TEMPLATE_DATA
-    }
-    requests_mocker.get(ConfigClass.METADATA_SERVICE + f'template/{template_id}/', json=mock_data)
-
-    headers = {'Authorization': jwt_token_admin}
-    params = {'manifest_id': template_id}
-    response = test_client.get(f'v1/export/manifest', query_string=params, headers=headers)
     assert response.status_code == 200
 
 
@@ -386,13 +377,21 @@ def test_attach_attributes_to_folder_contrib_200(test_client, requests_mocker,
 
     requests_mocker.get(ConfigClass.METADATA_SERVICE + f'item/{file_id}', json=mock_data)
 
+    # search for items recursively in folder
+    mock_data = {
+        'result': [
+        ]
+    }
+
+    requests_mocker.get(ConfigClass.METADATA_SERVICE + 'items/search/', json=mock_data)
+
     # update attributes for folder (bequeath)
     MOCK_FILE_DATA_ATTR = MOCK_FILE_DATA.copy()
     MOCK_FILE_DATA_ATTR['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
     mock_data = {
         'result': [MOCK_FILE_DATA_ATTR]
     }
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/bequeath/', json=mock_data)
+    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/', json=mock_data)
     headers = {'Authorization': jwt_token_contrib}
     payload = {
         'item_ids': [MOCK_FILE_DATA['id']],
@@ -404,9 +403,9 @@ def test_attach_attributes_to_folder_contrib_200(test_client, requests_mocker,
     assert response.status_code == 200
 
 
-def test_attach_attributes_to_folder_failed_contrib_500(test_client, requests_mocker,
-                                                        jwt_token_contrib, has_permission_true,
-                                                        has_project_contributor_role):
+def test_attach_attributes_to_folder_failed_folder_search_contrib_500(test_client, requests_mocker,
+                                                                      jwt_token_contrib, has_permission_true,
+                                                                      has_project_contributor_role):
     # get item by id
     file_id = MOCK_FILE_DATA['id']
     mock_data = {
@@ -415,11 +414,17 @@ def test_attach_attributes_to_folder_failed_contrib_500(test_client, requests_mo
 
     requests_mocker.get(ConfigClass.METADATA_SERVICE + f'item/{file_id}', json=mock_data)
 
+    # search for items recursively in folder
+    mock_data = {
+        'result': [
+        ]
+    }
+
+    requests_mocker.get(ConfigClass.METADATA_SERVICE + 'items/search/', json=mock_data, status_code=500)
+
     # update attributes for folder (bequeath)
     MOCK_FILE_DATA_ATTR = MOCK_FILE_DATA.copy()
     MOCK_FILE_DATA_ATTR['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
-    mock_data = {}
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/bequeath/', json=mock_data, status_code=500)
     headers = {'Authorization': jwt_token_contrib}
     payload = {
         'item_ids': [MOCK_FILE_DATA['id']],
@@ -450,21 +455,25 @@ def test_attach_attributes_to_file_and_folder_contrib_200(test_client, requests_
     requests_mocker.get(ConfigClass.METADATA_SERVICE + f'item/{file_id_1}', json=mock_data_folder)
     requests_mocker.get(ConfigClass.METADATA_SERVICE + f'item/{file_id_2}', json=mock_data_file)
 
-    # update attributes for folder (bequeath)
-    MOCK_FILE_DATA_ATTR_1['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
+    # search for files recursively in folder
     mock_data = {
-        'result': [MOCK_FILE_DATA_ATTR_1]
-    }
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/bequeath/', json=mock_data)
-
-    # update attributes for file
-    MOCK_FILE_DATA_ATTR_2['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
-    mock_data2 = {
         'result': [
-            MOCK_FILE_DATA_ATTR_2
         ]
     }
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/', json=mock_data2)
+
+    requests_mocker.get(ConfigClass.METADATA_SERVICE + 'items/search/', json=mock_data)
+
+    # update attributes for file and folder
+    MOCK_FILE_DATA_ATTR_1['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
+
+    MOCK_FILE_DATA_ATTR_2['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
+
+    mock_data = {
+        'result': [
+            MOCK_FILE_DATA_ATTR_1, MOCK_FILE_DATA_ATTR_2
+        ]
+    }
+    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/', json=mock_data)
 
     headers = {'Authorization': jwt_token_contrib}
     payload = {
@@ -475,45 +484,3 @@ def test_attach_attributes_to_file_and_folder_contrib_200(test_client, requests_
     }
     response = test_client.post(f'v1/file/attributes/attach', json=payload, headers=headers)
     assert response.status_code == 200
-
-
-def test_attach_attributes_to_file_failed_contrib_500(test_client, requests_mocker,
-                                                      jwt_token_contrib, has_permission_true,
-                                                      has_project_contributor_role):
-    MOCK_FILE_DATA_ATTR_1 = MOCK_FILE_DATA.copy()
-    MOCK_FILE_DATA_ATTR_2 = MOCK_FILE_DATA_2.copy()
-
-    # get item by id
-    file_id_1 = MOCK_FILE_DATA_ATTR_1['id']
-    mock_data_folder = {
-        'result': MOCK_FILE_DATA_ATTR_1
-    }
-    file_id_2 = MOCK_FILE_DATA_ATTR_2['id']
-    mock_data_file = {
-        'result': MOCK_FILE_DATA_ATTR_2
-    }
-
-    requests_mocker.get(ConfigClass.METADATA_SERVICE + f'item/{file_id_1}', json=mock_data_folder)
-    requests_mocker.get(ConfigClass.METADATA_SERVICE + f'item/{file_id_2}', json=mock_data_file)
-
-    # update attributes for folder (bequeath)
-    MOCK_FILE_DATA_ATTR_1['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
-    mock_data = {
-        'result': [MOCK_FILE_DATA_ATTR_1]
-    }
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/bequeath/', json=mock_data)
-
-    # update attributes for file
-    MOCK_FILE_DATA_ATTR_2['extended']['extra']['attributes'] = {template_id: {'attr1': 'A'}}
-    mock_data2 = {}
-    requests_mocker.put(ConfigClass.METADATA_SERVICE + 'items/batch/', json=mock_data2, status_code=500)
-
-    headers = {'Authorization': jwt_token_contrib}
-    payload = {
-        'item_ids': [MOCK_FILE_DATA['id'], MOCK_FILE_DATA_2['id']],
-        'manifest_id': template_id,
-        'project_code': MOCK_FILE_DATA['container_code'],
-        'attributes': {'attr1': 'A'}
-    }
-    response = test_client.post(f'v1/file/attributes/attach', json=payload, headers=headers)
-    assert response.status_code == 500


### PR DESCRIPTION
## Summary

- Fix error where non-admin users could not attach attributes to files in a project.
- Updated `DELETE /manifest/{id}` endpoint to check if manifest is attached to files before deletion.
- When attaching attributes to files within a folder, if a given file already has existing attributes attached, a termination operation_status is applied and returned in the response.
- Updated logic of `PUT /manifest/{id}`

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-1113

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor or reformatting

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

(Additional instructions for how to run tests or validate functionality if not covered by unit tests)

