### PR TITLE
get rid of build args in dev and set default env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM python:3.7-buster
 
-ARG MINIO_USERNAME
-ARG MINIO_PASSWORD
-
-ENV MINIO_USERNAME=$MINIO_USERNAME
-ENV MINIO_PASSWORD=$MINIO_PASSWORD
-
 RUN groupadd --gid 1004 deploy \
     && useradd --home-dir /home/deploy --create-home --uid 1004 \
         --gid 1004 --shell /bin/sh --skel /dev/null deploy
@@ -30,6 +24,7 @@ RUN chmod +x /home/deploy/gunicorn_starter.sh
 
 USER deploy
 ENV PATH="/home/deploy/.local/bin:${PATH}"
-ENV MINIO_USERNAME=$MINIO_USERNAME
-ENV MINIO_PASSWORD=$MINIO_PASSWORD
-CMD ["sh", "-c", "mc alias set minio http://minio.minio:9000 $MINIO_USERNAME $MINIO_PASSWORD && ./gunicorn_starter.sh"]
+ENV MINIO_USERNAME=minioadmin
+ENV MINIO_PASSWORD=minioadmin
+ENV MINIO_URL=http://minio.minio:9000
+CMD ["sh", "-c", "mc alias set minio $MINIO_URL $MINIO_USERNAME $MINIO_PASSWORD && ./gunicorn_starter.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,14 +42,10 @@ pipeline {
       when {branch "develop"}
       steps{
         script {
-            withCredentials([
-              usernamePassword(credentialsId:'minio', usernameVariable: 'MINIO_USERNAME', passwordVariable: 'MINIO_PASSWORD')
-            ]) {
-                docker.withRegistry('https://ghcr.io', registryCredential) {
-                    customImage = docker.build("$imagename_dev:$commit", "--build-arg MINIO_USERNAME=$MINIO_USERNAME --build-arg MINIO_PASSWORD=$MINIO_PASSWORD .")
-                    customImage.push()
-                }
-            }
+          docker.withRegistry('https://ghcr.io', registryCredential) {
+              customImage = docker.build("$imagename_dev:$commit", ".")
+              customImage.push()
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

minio credentials are no longer hard coded into the container with build args. 

## JIRA Issues

N/A

## Type of Change

Please delete options that are not relevant.

- [x] DevOps and Deployment

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

build and run
