### PR TITLE
bucket encryption can be disabled

### DIFF
--- a/api/api_project_v2.py
+++ b/api/api_project_v2.py
@@ -162,8 +162,13 @@ def create_minio_bucket(project_code: str) -> None:
         for bucket_prefix in prefixs:
             bucket_name = bucket_prefix + project_code
             asyncio.run(boto_client.create_bucket(bucket_name))
-            asyncio.run(boto_client.create_bucket_encryption(bucket_name))
             asyncio.run(boto_client.set_bucket_versioning(bucket_name))
+
+            if ConfigClass.MINIO_BUCKET_ENCRYPTION:
+                _logger.info('Bucket encyrption enabled, encrypting %s' % bucket_name)
+                asyncio.run(boto_client.create_bucket_encryption(bucket_name))
+            else:
+                _logger.warn('Bucket encryption is not enabled, not encrypting %s' % bucket_name)
 
             mc = asyncio.run(get_minio_policy_client(
                 ConfigClass.MINIO_ENDPOINT,

--- a/config.py
+++ b/config.py
@@ -138,6 +138,7 @@ class Settings(BaseSettings):
     MINIO_ACCESS_KEY: str
     MINIO_SECRET_KEY: str
     MINIO_HTTPS: bool = False
+    MINIO_BUCKET_ENCRYPTION: bool = True
 
     RESOURCES: List[str] = ["SuperSet", "Guacamole"]
 


### PR DESCRIPTION
## Summary

The behaviour of enabling bucket encryption on project creation can be enabled or disabled through config settings. This is useful when our S3 backend is not really S3 (minio gateway, radosGW... etc)

## JIRA Issues

N/A

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [x] No

## Test Directions

Tests should continue to pass and we will need to run some integration tests in new env to validate if change worked. 

