### PR TITLE
option for setting gid number in ldap group creation

### DIFF
--- a/api/api_project_v2.py
+++ b/api/api_project_v2.py
@@ -15,6 +15,7 @@
 import asyncio
 import re
 from uuid import uuid4
+import random
 
 import ldap
 import ldap.modlist as modlist
@@ -211,8 +212,16 @@ def ldap_create_user_group(code, description):
         objectclass = [ConfigClass.LDAP_objectclass.encode('utf-8')]
         attrs = {'objectclass': objectclass,
                  ConfigClass.LDAP_USER_OBJECTCLASS: f'{ConfigClass.AD_PROJECT_GROUP_PREFIX}-{code}'.encode('utf-8')}
+        
         if description:
             attrs['description'] = description.encode('utf-8')
+
+        # TODO: Do a preflight check here to see if GID is already taken
+        # before continuing by making use of LDAP search functionalities
+        if ConfigClass.LDAP_SET_GIDNUMBER:
+            gid = random.randint(ConfigClass.LDAP_GID_LOWER_BOUND, ConfigClass.LDAP_GID_UPPER_BOUND)
+            attrs['gidNumber'] = str(gid).encode('utf-8')
+
         ldif = modlist.addModlist(attrs)
         conn.add_s(dn, ldif)
     except Exception as error:

--- a/config.py
+++ b/config.py
@@ -116,8 +116,8 @@ class Settings(BaseSettings):
     LDAP_objectclass: str
     LDAP_USER_OBJECTCLASS: str
     LDAP_SET_GIDNUMBER: bool = False
-    LDAP_GID_LOWER_BOUND = 30000
-    LDAP_GID_UPPER_BOUND = 40000
+    LDAP_GID_LOWER_BOUND: int = 30000
+    LDAP_GID_UPPER_BOUND: int = 40000
 
     # Domain
     SITE_DOMAIN: str

--- a/config.py
+++ b/config.py
@@ -115,6 +115,9 @@ class Settings(BaseSettings):
     LDAP_DC2: str
     LDAP_objectclass: str
     LDAP_USER_OBJECTCLASS: str
+    LDAP_SET_GIDNUMBER: bool = False
+    LDAP_GID_LOWER_BOUND = 30000
+    LDAP_GID_UPPER_BOUND = 40000
 
     # Domain
     SITE_DOMAIN: str


### PR DESCRIPTION
## Summary

New config values with defaults:
```python
    LDAP_SET_GIDNUMBER: bool = False
    LDAP_GID_LOWER_BOUND = 30000
    LDAP_GID_UPPER_BOUND = 40000
```

When `LDAP_SET_GIDNUMBER` is set to True, LDAP will assign the `gidNumber` field for the ldif on group creation. 

Default value is `False` so it should be backwards compatible. 

## JIRA Issues

N/A

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [x] No

## Test Directions

This will need to be tested through integration in the Azure environment. 

